### PR TITLE
Add Crystal ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj/
 riderModule.iml
 /_ReSharper.Caches/
 *.DotSettings.user
+**/*.DS_Store

--- a/Core.Test/Core.Test.csproj
+++ b/Core.Test/Core.Test.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.8.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Core\Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Core.Test/CrystalTest.cs
+++ b/Core.Test/CrystalTest.cs
@@ -1,0 +1,43 @@
+namespace Core.Test;
+
+using FluentAssertions;
+
+public class CrystalTest
+{
+    [Fact]
+    public void RapidGenerationIsMonotonicallyIncreasing()
+    {
+        var crystals = new Crystal[10000];
+        for (var i = 0; i < crystals.Length; i++)
+        {
+            crystals[i] = Crystal.New();
+        }
+
+        var nonRandomBits = crystals.Select(c => c.WithoutNoise()).ToArray();
+        nonRandomBits.Should().BeInAscendingOrder();
+    }
+
+    [Fact]
+    public void SlowGenerationIsStrictlyIncreasing()
+    {
+        var crystals = new Crystal[50];
+        for (var i = 0; i < crystals.Length; i++)
+        {
+            crystals[i] = Crystal.New();
+            Thread.Sleep(20);
+        }
+
+        var nonRandomBits = crystals.Select(c => c.WithoutNoise());
+        nonRandomBits.Should().BeInAscendingOrder().And.OnlyHaveUniqueItems();
+    }
+}
+
+file static class CrystalUtils
+{
+    public static ulong WithoutNoise(this Crystal crystal)
+    {
+        ulong mask = 0xFFFF;
+        mask = ~mask;
+        return crystal.Value & mask;
+    }
+}

--- a/Core.Test/Usings.cs
+++ b/Core.Test/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+</Project>

--- a/Core/Crystal.cs
+++ b/Core/Crystal.cs
@@ -1,0 +1,26 @@
+namespace Core;
+
+public readonly record struct Crystal (ulong Value)
+{
+    /// <summary>
+    /// Crystal is our take on Discord/Twitter's Snowflake and UUID7. Since we do not operate
+    /// at scale and are not distributed, we forgo encoding machine/worker ID (like in Snowflake)
+    /// and use only 64-bits (unlike UUID7 which is 128-bit).
+    ///
+    /// The format of the Crystal is as follows:
+    /// Bits 64 to 16: Milliseconds since Unix epoch
+    /// Bits 15 to 0: Randomly generated noise
+    ///
+    /// This allows for randomly generated, but ordered, IDs that we can use as primary keys in our database 
+    /// </summary>
+    public static Crystal New()
+    {
+        var milliseconds = (ulong) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        
+        Span<byte> noiseBytes = stackalloc byte[2];
+        Random.Shared.NextBytes(noiseBytes);
+        var noise = BitConverter.ToUInt16(noiseBytes);
+
+        return new Crystal((milliseconds << 16) + noise);
+    }
+}

--- a/NuecesHomiesBot.sln
+++ b/NuecesHomiesBot.sln
@@ -4,6 +4,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Integrations", "Integration
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Integrations.Test", "Integrations.Test\Integrations.Test.csproj", "{7E18744C-D181-400D-A11D-DE915DC9CE99}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "Core\Core.csproj", "{B6937476-1A7D-45E7-BD35-D7B000F0F5B5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core.Test", "Core.Test\Core.Test.csproj", "{24E19A7A-01BE-4C3D-B2CE-4019FB42383C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +22,13 @@ Global
 		{7E18744C-D181-400D-A11D-DE915DC9CE99}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7E18744C-D181-400D-A11D-DE915DC9CE99}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E18744C-D181-400D-A11D-DE915DC9CE99}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6937476-1A7D-45E7-BD35-D7B000F0F5B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6937476-1A7D-45E7-BD35-D7B000F0F5B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6937476-1A7D-45E7-BD35-D7B000F0F5B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6937476-1A7D-45E7-BD35-D7B000F0F5B5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24E19A7A-01BE-4C3D-B2CE-4019FB42383C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24E19A7A-01BE-4C3D-B2CE-4019FB42383C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24E19A7A-01BE-4C3D-B2CE-4019FB42383C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24E19A7A-01BE-4C3D-B2CE-4019FB42383C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Crystal is our take on [Discord](https://discord.com/developers/docs/reference#snowflakes) or [Twitter's](https://blog.twitter.com/engineering/en_us/a/2010/announcing-snowflake) Snowflake and [UUID7](https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-01.html#section-4.4). Since we do not operate at scale and are not distributed, we forgo encoding machine/worker ID (like in Snowflake) and use only 64-bits (unlike UUID7 which is 128-bit).

The format of the Crystal is as follows:

| Start Bit | End Bit | Length | Description
--------- |---------|-------|-------------
64 | 16 | 48 | Milliseconds since Unix epoch
15 | 0 | 16 | Randomly generated noise


This allows for randomly generated, but ordered, IDs that we can use as primary keys in our database. 